### PR TITLE
Spelling mistake in documentation

### DIFF
--- a/docs/plowdown.1
+++ b/docs/plowdown.1
@@ -295,7 +295,7 @@ module name
 newline
 .TP
 \fI%s\fR
-destination (local) file size (positive interger in bytes).
+destination (local) file size (positive integer in bytes).
 Important: Empty string is returned when \fB--skip\-final\fR switch is specified.
 .TP
 \fI%t\fR

--- a/docs/plowup.1
+++ b/docs/plowup.1
@@ -244,7 +244,7 @@ module name
 newline
 .TP
 \fI%s\fR
-filesize (positive interger in bytes)
+filesize (positive integer in bytes)
 .TP
 \fI%t\fR
 tabulation character


### PR DESCRIPTION
There is a minor typo in the documentation.
