### PR TITLE
Update recaptcha_process

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -1850,7 +1850,7 @@ captcha_process() {
 # stdout: On 3 lines: <word> \n <challenge> \n <transaction_id>
 recaptcha_process() {
     local -r RECAPTCHA_SERVER='http://www.google.com/recaptcha/api/'
-    local URL="${RECAPTCHA_SERVER}challenge?k=${1}&ajax=1"
+    local URL="${RECAPTCHA_SERVER}challenge?k=${1}"
     local VARS SERVER TRY CHALLENGE FILENAME WORDS TID
 
     VARS=$(curl -L "$URL") || return

--- a/src/core.sh
+++ b/src/core.sh
@@ -1863,6 +1863,10 @@ recaptcha_process() {
     SERVER=$(echo "$VARS" | parse_quiet 'server' "server[[:space:]]\?:[[:space:]]\?'\([^']*\)'") || return
     CHALLENGE=$(echo "$VARS" | parse_quiet 'challenge' "challenge[[:space:]]\?:[[:space:]]\?'\([^']*\)'") || return
 
+    # Result: Recaptcha.finish_reload('...', 'image');
+    VARS=$(curl "${SERVER}reload?k=${1}&c=${CHALLENGE}&reason=i&type=image&lang=en") || return
+    CHALLENGE=$(echo "$VARS" | parse 'finish_reload' "('\([^']*\)") || return
+
     log_debug "reCaptcha server: $SERVER"
 
     # Image dimension: 300x57


### PR DESCRIPTION
The recaptcha process was slightly changed. We have to send to the recaptcha server the following request before we get a first recaptcha image:

`curl "${SERVER}reload?k=${1}&c=${CHALLENGE}&reason=i&type=image&lang=en"`

Otherwise we may get an unresolved first recaptcha like this:

![1-plowdown 5681 22580 recaptcha](https://cloud.githubusercontent.com/assets/8607499/12989264/f4d3a7e6-d104-11e5-94bb-a3fe36f115f6.jpg)

This issue affects services that show recaptcha on the next page (not on the first page) like lunaticfiles, filejoker, salefiles and others. To be honest I don't know exact reason why this is happen. For example catshare show recaptcha on the first page and it is not affected. Nevertheless in all those services (including catshare) a browser send the above request to the recaptcha server before getting a first recaptcha image.

The recapatcha process can be checked with the following test file:
https://filejoker.net/jeoebltw71ey

Feel free to review/change those commits.
