### PR TITLE
upload.sh: check if LOCALFILE contains ';' or ','

### DIFF
--- a/src/upload.sh
+++ b/src/upload.sh
@@ -476,7 +476,7 @@ for FILE in "${COMMAND_LINE_ARGS[@]}"; do
         DESTFILE=$(pretty_name_print DATA[@] "$NAME_FORMAT")
     fi
 
-    if match '[;,]' "$DESTFILE"; then
+    if match '[;,]' "$LOCALFILE" || match '[;,]' "$DESTFILE"; then
         log_notice "Skipping ($LOCALFILE): curl can't upload filenames that contain , or ;"
         continue
     fi


### PR DESCRIPTION
Otherwise we may get an error during uploading:

```
$ plowup 1fichier 'Test ;file 5MiB.zip':'Test file 5MiB.zip'
plowup: force captcha method (x11)
Starting upload (1fichier): Test ;file 5MiB.zip
Destination file: Test file 5MiB.zip
Warning: skip unknown form field: file 5MiB.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (26) couldn't open file "Test "
curl: failed with exit code 26
Failed inside 1fichier_upload() [3]
```
