### PR TITLE
core.sh: follow symbolic links during finding modules

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -2747,7 +2747,7 @@ get_all_modules_list() {
         while read -r; do
             D=$(dirname "$REPLY")
             SRCS+=( "$D" )
-        done < <(find "$PLOWSHARE_CONFDIR/modules.d/" -mindepth 2 -maxdepth 2 -name config)
+        done < <(find -L "$PLOWSHARE_CONFDIR/modules.d/" -mindepth 2 -maxdepth 2 -name config)
     fi
 
     for D in "${SRCS[@]}"; do


### PR DESCRIPTION
For me it's convenient to keep modules elsewhere then `~/.config/plowshare/modules.d/legacy.git`. This is a minor change, but maybe someone else will benefit from it too.
