### PR TITLE
core: support --run-* with spaces

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -3273,7 +3273,7 @@ translate_exec() {
         return $ERR_FATAL
     fi
 
-    echo "$F"
+    quote "$F"
 }
 
 # Check for positive speed rate


### PR DESCRIPTION
Usually `--run-*` are used with simple path, without spaces, but I'm using a local script, which happend to be in folder with spaces. Using `quote` instead of `echo` seems to do the trick.