### PR TITLE
core: follow symlink for check of plowshare.conf

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -3022,7 +3022,7 @@ process_configfile_module_options() {
         if [ "$CONFIG" != '/etc/plowshare.conf' ]; then
             if [ -O "$CONFIG" ]; then
                 # First 10 characters: access rights (human readable form)
-                local FILE_PERM=$(ls -l "$CONFIG" 2>/dev/null)
+                local FILE_PERM=$(ls -l -L "$CONFIG" 2>/dev/null)
 
                 if [[ ${FILE_PERM:4:6} != '------' ]]; then
                     log_notice "WARNING: Wrong configuration file permissions. Fix it with: chmod 600 $CONFIG"


### PR DESCRIPTION
When ~/.config/plowshare/plowshare.conf is a symbolic link in order to
check file permissions, we have to dereference it. Otherwise the
security check is errorneously made on on the symbolic link itself
although only the permissions of the real file are of interest.