### PR TITLE
version: Allow to override build date

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -8,10 +8,13 @@ if [ $# -ne 0 ]; then
   echo 'warning: this script does not take any argument.' >&2
 fi
 
+DATE_FMT="%Y-%m-%d"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+date=$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")
+
 # Check environment variable PLOWSHARE_FORCE_VERSION
 # For example: "1.0.1"
 if [ -n "$PLOWSHARE_FORCE_VERSION" ]; then
-  date=$(date +'%Y-%m-%d')
   echo "v${PLOWSHARE_FORCE_VERSION#v} ($date)"
 elif git rev-parse --is-inside-work-tree 1>/dev/null 2>&1; then
   rev=$(git describe --always --tags)
@@ -19,6 +22,5 @@ elif git rev-parse --is-inside-work-tree 1>/dev/null 2>&1; then
   echo "$rev ($date)"
 else
   echo 'warning: unable to detect plowshare version.' >&2
-  date=$(date +'%Y-%m-%d')
   echo "UNKNOWN ($date)"
 fi


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

this patch works with GNU date and BSD date variants

Without the patch, we get such diffs when building packages for openSUSE:
http://rb.zq1.de/compare.factory-20170807/plowshare-compare.out