### PR TITLE
Changed create_tempfile() permission from 600 to 644

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -1249,7 +1249,7 @@ create_tempfile() {
     local -r SUFFIX=$1
     local FILE="$TMPDIR/$(basename_file "$0").$$.$RANDOM$SUFFIX"
 
-    if touch "$FILE" && chmod 600 "$FILE"; then
+    if touch "$FILE" && chmod 644 "$FILE"; then
         echo "$FILE"
         return 0
     fi


### PR DESCRIPTION
I don't know if setting permissions to 644 for temp files causes troubles but I couldn't open the image from a webserver (symlinked /tmp to /var/www/html/tmp) and changing this made it working.